### PR TITLE
fix: replace the value in the slice when using the slog.LogValue interface

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -32,16 +32,12 @@ func AppendRecordAttrsToAttrs(attrs []slog.Attr, groups []string, record *slog.R
 }
 
 func ReplaceAttrs(fn ReplaceAttrFn, groups []string, attrs ...slog.Attr) []slog.Attr {
-	if fn == nil {
-		return attrs
-	}
-
 	for i := range attrs {
 		attr := attrs[i]
 		value := attr.Value.Resolve()
 		if value.Kind() == slog.KindGroup {
-			attr.Value = slog.GroupValue(ReplaceAttrs(fn, append(groups, attr.Key), value.Group()...)...)
-		} else {
+			attrs[i].Value = slog.GroupValue(ReplaceAttrs(fn, append(groups, attr.Key), value.Group()...)...)
+		} else if fn != nil {
 			attrs[i] = fn(groups, attr)
 		}
 	}


### PR DESCRIPTION
I really liked your contribution to the community and I'm using it a lot, congratulations on the great work.

During my use I came across the following problem, when saving the logs in Apache Loki, it was not resolving the use of structs

Memory usage in slices
![image](https://github.com/samber/slog-common/assets/378956/e4542c74-a40b-4c6d-a762-260c59db54db)

Apache Loki
![image](https://github.com/samber/slog-common/assets/378956/9ed7e18b-7273-480e-9cf6-59ae4ff9243f)
