### PR TITLE
feat: mount source using slog.Group

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -254,14 +254,18 @@ func FormatRequest(req *http.Request, ignoreHeaders bool) map[string]any {
 func Source(sourceKey string, r *slog.Record) slog.Attr {
 	fs := runtime.CallersFrames([]uintptr{r.PC})
 	f, _ := fs.Next()
-	return slog.Any(
-		sourceKey,
-		&slog.Source{
-			Function: f.Function,
-			File:     f.File,
-			Line:     f.Line,
-		},
-	)
+	var args []any
+	if f.Function != "" {
+		args = append(args, slog.String("function", f.Function))
+	}
+	if f.File != "" {
+		args = append(args, slog.String("file", f.File))
+	}
+	if f.Line != 0 {
+		args = append(args, slog.Int("line", f.Line))
+	}
+
+	return slog.Group(sourceKey, args...)
 }
 
 func StringSource(sourceKey string, r *slog.Record) slog.Attr {


### PR DESCRIPTION
I kept the same behavior as stdlib, where it creates a group and does not return the strutc Source as a value
![image](https://github.com/samber/slog-common/assets/378956/39077594-99e8-4b0b-9a09-f0110f8702e3)

grafana loki
![image](https://github.com/samber/slog-common/assets/378956/9e824896-b69b-4680-9648-61f06ab06406)
