### PR TITLE
feat(formaterror): add support for log valuer

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -217,7 +217,11 @@ func FormatErrorKey(values map[string]any, errorKeys ...string) map[string]any {
 	return values
 }
 
-func FormatError(err error) map[string]any {
+func FormatError(err error) any {
+	if e, ok := err.(slog.LogValuer); ok {
+		return e.LogValue()
+	}
+
 	return map[string]any{
 		"kind":  reflect.TypeOf(err).String(),
 		"error": err.Error(),

--- a/attributes_test.go
+++ b/attributes_test.go
@@ -373,6 +373,35 @@ func TestExtractError(t *testing.T) {
 	is.EqualError(err, assert.AnError.Error())
 }
 
+type testError struct {
+}
+
+func (t testError) Error() string {
+	return "test error"
+}
+
+func (t testError) LogValue() slog.Value {
+	return slog.StringValue("an error")
+}
+
+func TestFormatError(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	// not found
+	attrs := FormatError(assert.AnError)
+	is.Len(attrs, 3)
+	is.Equal(map[string]any{
+		"kind":  "*errors.errorString",
+		"error": assert.AnError.Error(),
+		"stack": nil,
+	}, attrs)
+
+	// not found
+	attrs = FormatError(&testError{})
+	is.Equal(slog.StringValue("an error"), attrs)
+}
+
 func TestRemoveEmptyAttrs(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
#8 

introducing a breaking change, since the function now returns `any`