### PR TITLE
ci: add dependabot automerge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,0 +1,25 @@
+name: Dependabot automerge
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+
+      - name: Enable auto-merge for github-actions updates
+        if: steps.metadata.outputs.package-ecosystem == 'github_actions'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Add `dependabot-automerge.yaml` workflow to automatically merge Dependabot PRs for GitHub Actions updates.